### PR TITLE
Update mongojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/nytr0gen/mongo-cookie-monster",
   "dependencies": {
     "deasync": "^0.1.0",
-    "mongojs": "^1.0.2",
+    "mongojs": "^2.4.0",
     "tough-cookie": "^1.1.0"
   }
 }


### PR DESCRIPTION
This enables support for Nodejs 6. 
The current mongojs version has a breaking change that is fixed by an update:
`TypeError: Proxy.create is not a function
    at module.exports (...\node_modules\mongojs\index.js:8:19`
